### PR TITLE
Replace custom cache layer by the official AWS one

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Endpoint: `POST /average-hours`
 
 The GRRR Slack workspace contains an app with exposes a slash command: `/average-hours [days]`.
 
-The Lambda function uses a Go written cache layer: [docs](https://aws.amazon.com/blogs/compute/caching-data-and-configuration-settings-with-aws-lambda-extensions/).
+The Lambda function uses a cache layer to make Parameter Store parameters available in the function:[docs](https://docs.aws.amazon.com/systems-manager/latest/userguide/ps-integration-lambda-extensions.html).
 
 ## Known issues and improvements
 

--- a/handler.js
+++ b/handler.js
@@ -10,7 +10,7 @@ const SlackClient = require("./src/slackClient");
 const fetchConfigurationVariables = async () => {
   // Load configuration from Parameter store via cache layer
   const response = await axios.get(
-    `http://127.0.0.1:2773/systemsmanager/parameters/get`,
+    `http://127.0.0.1:${process.env.PARAMETERS_SECRETS_EXTENSION_HTTP_PORT}/systemsmanager/parameters/get`,
     {
       params: {
         name: PARAMETER_NAME,

--- a/serverless.yml
+++ b/serverless.yml
@@ -33,6 +33,8 @@ functions:
   slack:
     handler: handler.slack
     timeout: 4
+    environment:
+      PARAMETERS_SECRETS_EXTENSION_HTTP_PORT: 2773
     layers:
       - "arn:aws:lambda:eu-central-1:187925254637:layer:AWS-Parameters-and-Secrets-Lambda-Extension:2"
     events:

--- a/serverless.yml
+++ b/serverless.yml
@@ -24,25 +24,17 @@ provider:
           Action:
             - "ssm:GetParameter"
           Resource: "arn:aws:ssm:eu-central-1:308691726112:parameter/slack_app_average_hours"
-
-layers:
-  cache:
-    path: ./lambda-cache-layer
-    name: Cache_Extension_Layer
-    compatibleRuntimes:
-      - nodejs12.x
-      - python3.8
-      - java11
-      - go1.x
+        - Effect: "Allow"
+          Action:
+            - "kms:Decrypt"
+          Resource: "arn:aws:kms:eu-central-1:308691726112:key/4acb0f04-da62-4a0d-b15d-d1b8843cf18e"
 
 functions:
   slack:
     handler: handler.slack
     timeout: 4
-    environment:
-      CACHE_EXTENSION_INIT_STARTUP: true
     layers:
-      - { Ref: CacheLambdaLayer }
+      - "arn:aws:lambda:eu-central-1:187925254637:layer:AWS-Parameters-and-Secrets-Lambda-Extension:2"
     events:
       - httpApi:
           path: /average-hours
@@ -52,4 +44,4 @@ resources:
   extensions:
     SlackLogGroup:
       Properties:
-        RetentionInDays: "30"
+        RetentionInDays: "14"


### PR DESCRIPTION
AWS announced their own cache layer: https://aws.amazon.com/about-aws/whats-new/2022/10/aws-parameters-secrets-lambda-extension/